### PR TITLE
radicle-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ ansible-galaxy install -r galaxy.yml --force
     ```yaml
     # group_vars/all/deploy-hooks.yml
     # Learn more on https://roots.io/trellis/docs/deploys/#hooks
-    deploy_after:
+    deploy_finalize_after:
       - "{{ playbook_dir }}/vendor/roles/itinerisltd.trellis-wordfence-kinsta/tasks/main.yml"
     ```
 
@@ -61,10 +61,10 @@ ansible-galaxy install -r galaxy.yml --force
 
 1. Setup the [role variables](#role-variables)
 2. [Deploy](https://roots.io/trellis/docs/deploys/#example)
-3. Tell Kinsta to add the `auto_prepend_file` variable that points to `{{ deploy_helper.current_path }}/web/wp/wordfence-waf.php`
+3. Tell Kinsta to add the `auto_prepend_file` variable that points to `{{ deploy_helper.current_path }}/config/wordfence-waf.php`
     1. `deploy_helper.shared_path` can differ between Trellis setups. Check for final path before asking Kinsta.
-    2. This is usually where the uploads are stored.
-    3. E.g. `auto_prepend_file = '/www/kinstauser_123/public/current/web/wp/wordfence-waf.php'`
+    2. This is the path to the Bedrock/Radicle configs.
+    3. E.g. `auto_prepend_file = '/www/kinstauser_123/public/current/config/wordfence-waf.php'`
 
 ## FAQs
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,5 +2,8 @@
 - name: Template wordfence-waf.php
   ansible.builtin.template:
     src: "../templates/wordfence-waf.php.j2"
-    dest: "{{ deploy_helper.new_release_path }}/web/wp/wordfence-waf.php"
+    dest: "{{ deploy_helper.new_release_path }}/config/wordfence-waf.php"
     mode: "0755"
+  with_dict: "{{ wordpress_sites }}"
+  vars:
+    project_plugins_path: "{{ project.plugins_path | default('app/plugins') }}"

--- a/templates/wordfence-waf.php.j2
+++ b/templates/wordfence-waf.php.j2
@@ -1,7 +1,8 @@
 <?php
 // Before removing this file, please verify the PHP ini setting `auto_prepend_file` does not point to this.
-
-if (file_exists('{{ deploy_helper.new_release_path }}/web/app/plugins/wordfence/waf/bootstrap.php')) {
-	define('WFWAF_LOG_PATH', '{{ deploy_helper.new_release_path }}/../../wflogs/');
-	include_once '{{ deploy_helper.new_release_path }}/web/app/plugins/wordfence/waf/bootstrap.php';
+if (file_exists('{{ deploy_helper.new_release_path }}/{{ project_public_path }}/{{ project_plugins_path }}/wordfence/waf/bootstrap.php')) {
+	if (! defined('WFWAF_LOG_PATH')) {
+		define('WFWAF_LOG_PATH', '{{ deploy_helper.new_release_path }}/../../wflogs/');
+	}
+	include_once '{{ deploy_helper.new_release_path }}/{{ project_public_path }}/{{ project_plugins_path }}/wordfence/waf/bootstrap.php';
 }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases, this will be possible.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug fix
- [x] Breaking change
- [x] Requires manual action post-deploy
- [ ] Optimisation
- [ ] Documentation update

## Description

[Radicle](https://github.com/roots/radicle) uses a different directory structure so we cannot assume/hardcode the path to the WordFence plugin directory (e.g. `~/public/current/web/app/plugins/wordfence/waf/bootstrap.php`).

This PR will set the default path to `~/public/current/web/app/plugins/wordfence/waf/bootstrap.php` but allows changing the path to the plugins directory using `project.plugins_path` in `group_vars/*/wordpress_sites.yml`.

```diff
# group_vars/production/wordpress_sites.yml
# Documentation: https://roots.io/trellis/docs/remote-server-setup/
# `wordpress_sites` options: https://roots.io/trellis/docs/wordpress-sites
# Define accompanying passwords/secrets in group_vars/production/vault.yml

wordpress_sites:
  example:
    site_hosts:
      - canonical: www.example.co.uk
    local_path: ../site # path targeting local Bedrock site directory (relative to Ansible root)
    public_path: public
    upload_path: content/uploads
+   plugins_path: content/plugins
    repo: git@github.com:vendor/example-radicle.git
    branch: main
    env:
      # Note that db_password is defined in `group_vars/<env>/vault.yml`
      db_prefix: ex_
      db_name: example
      db_user: example
    multisite:
      enabled: false
      subdomains: true
    ssl:
      enabled: true
      provider: self-signed # Doesn't matter. Just to keep Trellis happy
    cache:
      enabled: false
    sage: sage
```